### PR TITLE
fix(toggle-group): visible keyboard focus ring on toggle items

### DIFF
--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -129,6 +129,9 @@ const toggleGroupItemStyles = tv({
     isFocused: {
       true: 'not-selected:bg-(--toggle-focused-bg) not-selected:text-(--toggle-focused-fg) not-selected:[--toggle-icon:var(--toggle-focused-fg)]',
     },
+    isFocusVisible: {
+      true: 'inset-ring-2 inset-ring-ring',
+    },
     isHovered: {
       true: 'enabled:not-selected:bg-(--toggle-hover-bg) enabled:not-selected:text-(--toggle-hover-fg) enabled:not-selected:[--toggle-icon:var(--toggle-hover-fg)]',
     },
@@ -140,6 +143,11 @@ const toggleGroupItemStyles = tv({
     size: 'md',
   },
   compoundVariants: [
+    {
+      isSelected: true,
+      isFocusVisible: true,
+      className: 'inset-ring-(--toggle-selected-fg)',
+    },
     {
       selectionMode: 'multiple',
       orientation: 'horizontal',


### PR DESCRIPTION
## Problem

`ToggleGroupItem` has no keyboard focus ring. The base sets `outline-hidden`, and the only focus styling is the `isFocused` variant, which changes the **background** of `not-selected` items. So:

- A keyboard-focused toggle shows no ring.
- A **selected** focused item — e.g. the default segment of a `selectionMode="single"` group — has **no focus indicator at all** (fails WCAG 2.4.7 Focus Visible).

**Repro:** render any `<ToggleGroup selectionMode="single">`, Tab to it — the selected segment shows no visible focus state.

## Why it isn't a one-liner

- The group wrapper is `overflow-hidden`, so an outset / offset ring (like the one `Button` uses via `ring-offset-*`) gets clipped. The ring has to be **inset**.
- `--ring` equals `--primary` in the default theme (both `oklch(0.546 0.245 262.881)`), so a `--ring` ring is invisible against a selected item's `--primary` background.

## Fix

- New `isFocusVisible` variant → an inset ring reusing the item's existing inset-ring layer: `inset-ring-2 inset-ring-ring`.
- Compound `isSelected + isFocusVisible` → `inset-ring-(--toggle-selected-fg)`, so the ring contrasts against the selected (primary) surface.

Keyboard-only (`isFocusVisible`), +8 lines, no other component touched.

## Notes

I don't have `bun` on this machine, so I couldn't run `bun run lint` / `format` / `b` — the change is a self-contained `tv()` addition, hand-formatted to match the surrounding code; happy to tweak. I verified the equivalent inset-ring approach in a downstream Tailwind v4 app consuming these components: the focus ring is now visible on both the selected and unselected segments, in light and dark.
